### PR TITLE
Polish the guide for launch.

### DIFF
--- a/docs/partner_editable/_settings.adoc
+++ b/docs/partner_editable/_settings.adoc
@@ -1,9 +1,9 @@
 :quickstart-project-name: quickstart-etleap-etl
-:partner-product-name: ETL
+:partner-product-name: Etleap ETL
 :partner-company-name: Etleap
 :doc-month: August
 :doc-year: 2020
-:partner-contributors: Caius Brindescu and Christian Romming, {partner-company-name}
+:partner-contributors: Caius Brindescu and Archie Menzies, {partner-company-name}
 :quickstart-contributors: Dave May, Quick Start team
 :deployment_time: 30 minutes
 :default_deployment_region: us-east-1

--- a/docs/partner_editable/_settings.adoc
+++ b/docs/partner_editable/_settings.adoc
@@ -5,7 +5,7 @@
 :doc-year: 2020
 :partner-contributors: Caius Brindescu and Archie Menzies, {partner-company-name}
 :quickstart-contributors: Dave May, Quick Start team
-:deployment_time: 30 minutes
+:deployment_time: 20 minutes
 :default_deployment_region: us-east-1
 // Uncomment these two attributes if you are leveraging
 // - an AWS Marketplace listing.

--- a/docs/partner_editable/architecture.adoc
+++ b/docs/partner_editable/architecture.adoc
@@ -18,9 +18,9 @@ As shown in figure 1, the Quick Start sets up the following:
 ** An Amazon Relational Database Service (Amazon RDS) MySQL database used by {partner-company-name} to store metadata.
 ** An Amazon EMR cluster used by {partner-company-name} to run extractions and transformations.
 * An Amazon S3 bucket used by {partner-company-name} to store extracted and transformed data.
-* Two AWS Key Management Service (AWS KMS) keys in different AWS Regions used to encrypt secrets within {partner-company-name}.
+* One AWS Key Management Service (AWS KMS) key used to encrypt secrets within {partner-company-name}.
 * Four AWS Identity and Access Management (IAM) roles:
 ** One attached to the {partner-company-name} Amazon EC2 instance.
 ** One attached to the Amazon EMR cluster nodes.
-** One used by Amazon EMR for auto scaling.
-** One used to access data in the Amazon S3 bucket. 
+** One used by Amazon EMR for provisioning and service-level actions (see https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-iam-role.html[EMR Role^]).
+** One used by Amazon EMR for auto scaling (see https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-iam-role-automatic-scaling.html[Auto Scaling Role^]).

--- a/docs/partner_editable/licenses.adoc
+++ b/docs/partner_editable/licenses.adoc
@@ -1,4 +1,4 @@
 // Include details about the license and how they can sign up. If no license is required, clarify that. 
 
 // Or, if the deployment uses an AMI, update this paragraph. If it doesn’t, remove the paragraph.
-This Quick Start requires either a subscription to the Amazon Machine Image (AMI) for {partner-company-name} or a license provided by {partner-company-name}. An AMI subscription is available from https://aws.amazon.com/marketplace/pp/B07NM5J1PB?qid=1594321833265&sr=0-1&ref_=srh_res_product_title[AWS Marketplace^]. Additional pricing, terms, and conditions may apply. For instructions, see the *Deployment steps* section.
+This Quick Start requires either a subscription to the Amazon Machine Image (AMI) for {partner-company-name} or a license provided by {partner-company-name}. An AMI subscription is available from https://aws.amazon.com/marketplace/pp/B08C4KVR5Z[AWS Marketplace^]. Additional pricing, terms, and conditions may apply. For instructions, see the *Deployment steps* section.

--- a/docs/partner_editable/product_description.adoc
+++ b/docs/partner_editable/product_description.adoc
@@ -4,8 +4,8 @@
 
 {partner-product-name} is an extract, transform, and load (ETL) service for building data warehouses using Amazon Redshift and data lakes using Amazon Simple Storage Service (Amazon S3) and AWS Glue. Using {partner-company-name} on the AWS Cloud, you can:
 
-* Extract from any source, including databases, applications, files, and event streams. Even legacy on-premises sources can be integrated with no extra effort.
-* Transform and preview your data using the {partner-company-name} interactive data wrangler, without writing any code. Transformations run with automatic scaling on an Amazon EMR cluster, which is included with this Quick Start.
-* Load to an Amazon Redshift data warehouse or Amazon S3 with AWS Glue data lake for immediate analysis, on-demand access, and long-term archiving.
-* Model your data with SQL queries for unification and performance, and let {partner-company-name} maintain dependencies and orchestration.
-* Operate your pipelines without headaches. Automatic detection and guided resolution of schema changes and performance issues keep your data repository available, reliable, and fast.
+* *Extract* from any source, including databases, applications, files, and event streams. Even legacy on-premises sources can be integrated with no extra effort.
+* *Transform* and preview your data using the {partner-company-name} interactive data wrangler, without writing any code. Transformations run with automatic scaling on an Amazon EMR cluster, which is included with this Quick Start.
+* *Load* to an Amazon Redshift data warehouse or Amazon S3 with AWS Glue data lake for immediate analysis, on-demand access, and long-term archiving.
+* *Model* your data with SQL queries for unification and performance, and let {partner-company-name} maintain dependencies and orchestration.
+* *Operate* your pipelines without headaches. Automatic detection and guided resolution of schema changes and performance issues keep your data repository available, reliable, and fast.

--- a/docs/partner_editable/service_limits.adoc
+++ b/docs/partner_editable/service_limits.adoc
@@ -4,7 +4,6 @@
 
 // Space needed to maintain table headers
 |VPCs |1
-|Elastic IP addresses |1
 |AWS Identity and Access Management (IAM) security groups |1
 |IAM roles |4
 |Application Load Balancers |1


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Made the following changes:

- Changed our product name from 'ETL' to 'Etleap ETL' as there are several instances where the 'partner-product-name' variable is used on it's own (e.g. 'ETL on AWS').
- Changed the contributor from me to Archie, who has done a lot of the work on the templates.
- Changed the deployment time to 20 minutes, as we have consistently observed deployments taking less than this.
- We have switched from using two KMS keys to one due to CloudFormation restrictions on deployments being single-region.
- Clarified the origin of two of the roles, which are required by EMR.
- Re-pointing to the correct MR listing.
- Made the intro paragraph more readable by highlighting key words.
- Removed the reference to 'Elastic IP', which we're no longer using.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
