### PR TITLE
Added info about stack deletion

### DIFF
--- a/docs/partner_editable/faq_troubleshooting.adoc
+++ b/docs/partner_editable/faq_troubleshooting.adoc
@@ -14,3 +14,7 @@ For additional information, see https://docs.aws.amazon.com/AWSCloudFormation/la
 *Q.* I encountered a size limitation error when I deployed the AWS CloudFormation templates.
 
 *A.* Launch the Quick Start templates from the links in this guide or from another S3 bucket. If you deploy the templates from a local copy on your computer or from a location other than an S3 bucket, you might encounter template size limitations. For more information about AWS CloudFormation quotas, see the http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-limits.html[AWS documentation^].
+
+*Q.* When deleting the stack, I encounter an error that `Etleap-Deployment` deployment stack failed to delete
+
+*A.* This happens because of EMR security groups, and is a known limitation of CloudFormation. To get around this, you need to manually delete the embedded `Etleap-Deployment` stack again, and *retain* the `Etleap VPC` resource. Once the stack is deleted, you can delete the VPC from the AWS Console. You can also delete the top-level stack, and retain the `Etleap-Deployment` stack, as it has already been deleted.


### PR DESCRIPTION
If a stack deletion fails because of a VPC, we instruct the user to retain the resource and manually delete the VPC from the console.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
